### PR TITLE
Convert dataflow configurations in Arbitrary APK Installation query to use new module-configuration

### DIFF
--- a/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
@@ -28,21 +28,6 @@ private module ApkConf implements DataFlow::ConfigSig {
 
 module ApkConfiguration = DataFlow::Make<ApkConf>;
 
-// class ApkConfiguration extends DataFlow::Configuration {
-//   ApkConfiguration() { this = "ApkConfiguration" }
-//   override predicate isSource(DataFlow::Node node) { node instanceof ExternalApkSource }
-//   override predicate isSink(DataFlow::Node node) {
-//     exists(MethodAccess ma |
-//       ma.getMethod() instanceof SetDataMethod and
-//       ma.getArgument(0) = node.asExpr() and
-//       (
-//         any(PackageArchiveMimeTypeConfiguration c).hasFlowToExpr(ma.getQualifier())
-//         or
-//         any(InstallPackageActionConfiguration c).hasFlowToExpr(ma.getQualifier())
-//       )
-//     )
-//   }
-// }
 /**
  * A dataflow configuration tracking the flow from the `android.content.Intent.ACTION_INSTALL_PACKAGE`
  * constant to either the constructor of an intent or the `setAction` method of an intent.

--- a/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
@@ -10,12 +10,10 @@ private import semmle.code.java.security.ArbitraryApkInstallation
  * A dataflow configuration for flow from an external source of an APK to the
  * `setData[AndType][AndNormalize]` method of an intent.
  */
-class ApkConfiguration extends DataFlow::Configuration {
-  ApkConfiguration() { this = "ApkConfiguration" }
+private module ApkConf implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node instanceof ExternalApkSource }
 
-  override predicate isSource(DataFlow::Node node) { node instanceof ExternalApkSource }
-
-  override predicate isSink(DataFlow::Node node) {
+  predicate isSink(DataFlow::Node node) {
     exists(MethodAccess ma |
       ma.getMethod() instanceof SetDataMethod and
       ma.getArgument(0) = node.asExpr() and
@@ -28,6 +26,23 @@ class ApkConfiguration extends DataFlow::Configuration {
   }
 }
 
+module ApkConfiguration = DataFlow::Make<ApkConf>;
+
+// class ApkConfiguration extends DataFlow::Configuration {
+//   ApkConfiguration() { this = "ApkConfiguration" }
+//   override predicate isSource(DataFlow::Node node) { node instanceof ExternalApkSource }
+//   override predicate isSink(DataFlow::Node node) {
+//     exists(MethodAccess ma |
+//       ma.getMethod() instanceof SetDataMethod and
+//       ma.getArgument(0) = node.asExpr() and
+//       (
+//         any(PackageArchiveMimeTypeConfiguration c).hasFlowToExpr(ma.getQualifier())
+//         or
+//         any(InstallPackageActionConfiguration c).hasFlowToExpr(ma.getQualifier())
+//       )
+//     )
+//   }
+// }
 /**
  * A dataflow configuration tracking the flow from the `android.content.Intent.ACTION_INSTALL_PACKAGE`
  * constant to either the constructor of an intent or the `setAction` method of an intent.

--- a/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
@@ -2,6 +2,7 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.TaintTracking2
 import semmle.code.java.dataflow.TaintTracking3
 private import semmle.code.java.security.ArbitraryApkInstallation
@@ -18,9 +19,9 @@ private module ApkConf implements DataFlow::ConfigSig {
       ma.getMethod() instanceof SetDataMethod and
       ma.getArgument(0) = node.asExpr() and
       (
-        any(PackageArchiveMimeTypeConfiguration c).hasFlowToExpr(ma.getQualifier())
+        PackageArchiveMimeTypeConfiguration::hasFlowToExpr(ma.getQualifier())
         or
-        any(InstallPackageActionConfiguration c).hasFlowToExpr(ma.getQualifier())
+        InstallPackageActionConfiguration::hasFlowToExpr(ma.getQualifier())
       )
     )
   }
@@ -34,14 +35,14 @@ module ApkConfiguration = DataFlow::Make<ApkConf>;
  *
  * This is used to track if an intent is used to install an APK.
  */
-private class InstallPackageActionConfiguration extends TaintTracking3::Configuration {
-  InstallPackageActionConfiguration() { this = "InstallPackageActionConfiguration" }
+private module InstallPackageActionConfig implements DataFlow::StateConfigSig {
+  class FlowState = string;
 
-  override predicate isSource(DataFlow::Node source) {
-    source.asExpr() instanceof InstallPackageAction
+  predicate isSource(DataFlow::Node source, FlowState state) {
+    source.asExpr() instanceof InstallPackageAction and state instanceof DataFlow::FlowStateEmpty
   }
 
-  override predicate isAdditionalTaintStep(
+  predicate isAdditionalFlowStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,
     DataFlow::FlowState state2
   ) {
@@ -63,24 +64,30 @@ private class InstallPackageActionConfiguration extends TaintTracking3::Configur
     )
   }
 
-  override predicate isSink(DataFlow::Node node, DataFlow::FlowState state) {
+  predicate isSink(DataFlow::Node node, DataFlow::FlowState state) {
     state = "hasPackageInstallAction" and node.asExpr().getType() instanceof TypeIntent
   }
+
+  predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
 }
+
+private module InstallPackageActionConfiguration =
+  TaintTracking::MakeWithState<InstallPackageActionConfig>;
 
 /**
  * A dataflow configuration tracking the flow of the Android APK MIME type to
  * the `setType` or `setTypeAndNormalize` method of an intent, followed by a call
  * to `setData[AndType][AndNormalize]`.
  */
-private class PackageArchiveMimeTypeConfiguration extends TaintTracking2::Configuration {
-  PackageArchiveMimeTypeConfiguration() { this = "PackageArchiveMimeTypeConfiguration" }
+private module PackageArchiveMimeTypeConfig implements DataFlow::StateConfigSig {
+  class FlowState = string;
 
-  override predicate isSource(DataFlow::Node node) {
-    node.asExpr() instanceof PackageArchiveMimeTypeLiteral
+  predicate isSource(DataFlow::Node node, FlowState state) {
+    node.asExpr() instanceof PackageArchiveMimeTypeLiteral and
+    state instanceof DataFlow::FlowStateEmpty
   }
 
-  override predicate isAdditionalTaintStep(
+  predicate isAdditionalFlowStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,
     DataFlow::FlowState state2
   ) {
@@ -98,8 +105,13 @@ private class PackageArchiveMimeTypeConfiguration extends TaintTracking2::Config
     )
   }
 
-  override predicate isSink(DataFlow::Node node, DataFlow::FlowState state) {
+  predicate isSink(DataFlow::Node node, DataFlow::FlowState state) {
     state = "typeSet" and
     node instanceof SetDataSink
   }
+
+  predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
 }
+
+private module PackageArchiveMimeTypeConfiguration =
+  TaintTracking::MakeWithState<PackageArchiveMimeTypeConfig>;

--- a/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
@@ -3,8 +3,6 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.TaintTracking2
-import semmle.code.java.dataflow.TaintTracking3
 private import semmle.code.java.security.ArbitraryApkInstallation
 
 /**

--- a/java/ql/src/Security/CWE/CWE-094/ArbitraryApkInstallation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/ArbitraryApkInstallation.ql
@@ -14,6 +14,6 @@ import java
 import semmle.code.java.security.ArbitraryApkInstallationQuery
 import DataFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, ApkConfiguration config
-where config.hasFlowPath(source, sink)
+from DataFlow::PathNode source, DataFlow::PathNode sink
+where ApkConfiguration::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Arbitrary Android APK installation."

--- a/java/ql/src/Security/CWE/CWE-094/ArbitraryApkInstallation.ql
+++ b/java/ql/src/Security/CWE/CWE-094/ArbitraryApkInstallation.ql
@@ -12,8 +12,8 @@
 
 import java
 import semmle.code.java.security.ArbitraryApkInstallationQuery
-import DataFlow::PathGraph
+import ApkConfiguration::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink
+from ApkConfiguration::PathNode source, ApkConfiguration::PathNode sink
 where ApkConfiguration::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Arbitrary Android APK installation."

--- a/java/ql/test/query-tests/security/CWE-094/ApkInstallationTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/ApkInstallationTest.ql
@@ -10,7 +10,7 @@ class HasApkInstallationTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasApkInstallation" and
-    exists(DataFlow::Node sink, ApkConfiguration conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | ApkConfiguration::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""


### PR DESCRIPTION
Convert the configurations in Arbitrary APK installation to use the newer modules, since https://github.com/github/codeql/pull/12186